### PR TITLE
Fill in Part Two expected answers for y2024/d07, y2025/d01, y2025/d03

### DIFF
--- a/y2024/d07/solution_test.go
+++ b/y2024/d07/solution_test.go
@@ -31,7 +31,7 @@ func ExamplePartTwo() {
 	if err := PartTwo(file, os.Stdout); err != nil {
 		log.Fatalf("could not solve: %v", err)
 	}
-	// Output: 👉 Write the answer here 👈
+	// Output: 159490400628354
 }
 
 func Benchmark(b *testing.B) {

--- a/y2025/d01/solution_test.go
+++ b/y2025/d01/solution_test.go
@@ -31,7 +31,7 @@ func ExamplePartTwo() {
 	if err := PartTwo(file, os.Stdout); err != nil {
 		log.Fatalf("could not solve: %v", err)
 	}
-	// Output: 👉 Write the answer here 👈
+	// Output: 6860
 }
 
 func Benchmark(b *testing.B) {

--- a/y2025/d03/solution_test.go
+++ b/y2025/d03/solution_test.go
@@ -31,7 +31,7 @@ func ExamplePartTwo() {
 	if err := PartTwo(file, os.Stdout); err != nil {
 		log.Fatalf("could not solve: %v", err)
 	}
-	// Output: 👉 Write the answer here 👈
+	// Output: 173577199527257
 }
 
 func Benchmark(b *testing.B) {


### PR DESCRIPTION
The ExamplePartTwo tests in these three packages still had the
placeholder "👉 Write the answer here 👈" instead of the actual
computed answers, causing test failures.

https://claude.ai/code/session_01NVT92ngY7DzEoaHTYpp9bq